### PR TITLE
Include license in source distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="deep_autoviml",
-    version="0.0.78.dev1",
+    version="0.0.78.dev2",
     author="Ram Seshadri",
     # author_email="author@example.com",
     description="Automatically Build Deep Learning Models and Pipelines fast!",

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='Apache License 2.0',
+    license_files=("LICENSE",),
     url="https://github.com/AutoViML/deep_autoviml",
     packages = [
         "deep_autoviml",


### PR DESCRIPTION
The PyPI source does not have any license file in it (`v0.0.78.dev1`). This PR ensures inclusion of the license file (LICENSE) in the source distribution (`*.tar.gz`) file.

Closes #16 